### PR TITLE
refactor: replace deprecated Buffer api

### DIFF
--- a/decoder.js
+++ b/decoder.js
@@ -24,7 +24,7 @@ var PNG_HEADER = 1;
 var PNG_CHUNK = 2;
 var PNG_CRC = 3;
 
-var SIGNATURE = new Buffer([ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ]);
+var SIGNATURE = Buffer.from([ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ]);
 
 function PNGDecoder(options) {
   Transform.call(this);
@@ -228,7 +228,7 @@ PNGDecoder.prototype._initFrame = function() {
 
   this.scanlineLength = this.pixelBytes * this.format.width;
   this._previousScanline = null;
-  this._scanline = new Buffer(this.scanlineLength);
+  this._scanline = Buffer.alloc(this.scanlineLength);
 };
 
 // Reads the image palette chunk
@@ -461,7 +461,7 @@ PNGDecoder.prototype._decodePixels = function(data) {
         this.push(scanline);
 
       this._previousScanline = prev = scanline;
-      this._scanline = scanline = new Buffer(this.scanlineLength);
+      this._scanline = scanline = Buffer.alloc(this.scanlineLength);
       this._pixelOffset = off = 0;
       this._pixelType = -1;
     }
@@ -477,7 +477,7 @@ PNGDecoder.prototype._convertIndexedScanline = function(scanline) {
     return this.emit('error', new Error('Missing palette'));
 
   var alpha = this._transparencyIndex;
-  var buf = new Buffer(scanline.length * (alpha ? 4 : 3));
+  var buf = Buffer.alloc(scanline.length * (alpha ? 4 : 3));
   var p = 0;
 
   for (var i = 0; i < scanline.length; i++) {

--- a/encoder.js
+++ b/encoder.js
@@ -18,7 +18,7 @@ var PNG_FILTER_UP = 2;
 var PNG_FILTER_AVG = 3;
 var PNG_FILTER_PAETH = 4;
 
-var PNG_SIGNATURE = new Buffer([ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ]);
+var PNG_SIGNATURE = Buffer.from([ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ]);
 
 // color type and component count for each supported color space
 var PNG_COLOR_SPACES = {
@@ -141,13 +141,13 @@ PNGEncoder.prototype._end = function(done) {
     this._output.length = 0; // free memory
   }
   
-  this._writeChunk('IEND', new Buffer(0));    
+  this._writeChunk('IEND', Buffer.alloc(0));    
   done();
 }
 
 // Write's a generic PNG chunk including header, data, and CRC
 PNGEncoder.prototype._writeChunk = function(chunk, data) {
-  var header = new Buffer(8);
+  var header = Buffer.alloc(8);
   header.writeUInt32BE(data.length, 0);
   header.write(chunk, 4, 4, 'ascii');
   
@@ -159,7 +159,7 @@ PNGEncoder.prototype._writeChunk = function(chunk, data) {
 };
 
 PNGEncoder.prototype._writeIHDR = function() {
-  var chunk = new Buffer(13);
+  var chunk = Buffer.alloc(13);
   chunk.writeUInt32BE(this.format.width, 0);
   chunk.writeUInt32BE(this.format.height, 4);
   chunk[8] = 8; // bits
@@ -177,8 +177,8 @@ PNGEncoder.prototype._writePLTE = function() {
   // check if the palette contains transparency
   // if so, we need to separate it out into the tRNS chunk
   if (palette.length % 4 === 0) {
-    var plte = new Buffer(palette.length / 4 * 3);
-    var trns = new Buffer(palette.length / 4);
+    var plte = Buffer.alloc(palette.length / 4 * 3);
+    var trns = Buffer.alloc(palette.length / 4);
     var p = 0, t = 0;
     
     for (var i = 0; i < palette.length;) {
@@ -204,7 +204,7 @@ PNGEncoder.prototype._writePLTE = function() {
 
 // For animated PNGs, the acTL chunk is the animation header
 PNGEncoder.prototype._writeacTL = function() {
-  var buf = new Buffer(8);
+  var buf = Buffer.alloc(8);
     
   buf.writeUInt32BE(this._numFrames, 0);
   buf.writeUInt32BE(this.format.repeatCount === Infinity ? 0 : (this.format.repeatCount || 1), 4);
@@ -214,7 +214,7 @@ PNGEncoder.prototype._writeacTL = function() {
 
 // For animated PNGs, the fcTL chunk stores the header for a frame
 PNGEncoder.prototype._writefcTL = function(frame) {
-  var buf = new Buffer(26);
+  var buf = Buffer.alloc(26);
   
   buf.writeUInt32BE(this._sequence++, 0);
   buf.writeUInt32BE(frame.width || this.format.width, 4);
@@ -236,7 +236,7 @@ PNGEncoder.prototype._writeIDAT = function(data) {
 
 // Subsequent frame data for animated PNGs
 PNGEncoder.prototype._writefdAT = function(data) {
-  var buf = new Buffer(4 + data.length);
+  var buf = Buffer.alloc(4 + data.length);
   
   buf.writeUInt32BE(this._sequence++, 0);
   data.copy(buf, 4);
@@ -247,8 +247,8 @@ PNGEncoder.prototype._writefdAT = function(data) {
 // Chooses the best filter for a given scanline.
 // Tries them all and chooses the one with the lowest sum.
 PNGEncoder.prototype._filter = function(scanline) {
-  var out = new Buffer(1 + scanline.length);
-  var tmp = new Buffer(1 + scanline.length);
+  var out = Buffer.alloc(1 + scanline.length);
+  var tmp = Buffer.alloc(1 + scanline.length);
   var prev = this._prevScanline;
   var b = this._pixelBytes;
   var min = Infinity;

--- a/test/decoder.js
+++ b/test/decoder.js
@@ -7,7 +7,7 @@ describe('PNGDecoder', function() {
   it('can probe to see if a file is a png', function() {
     var file = fs.readFileSync(__dirname + '/images/trees.png');
     assert(PNGDecoder.probe(file));
-    assert(!PNGDecoder.probe(new Buffer(100)));
+    assert(!PNGDecoder.probe(Buffer.alloc(100)));
   });
 
   it('decodes an RGB image', function(done) {

--- a/test/encoder.js
+++ b/test/encoder.js
@@ -7,7 +7,7 @@ var PassThrough = require('stream').PassThrough;
 
 describe('PNGEncoder', function() {
   it('encodes an RGB image', function(done) {
-    var pixels = new Buffer(10 * 10 * 3);
+    var pixels = Buffer.alloc(10 * 10 * 3);
     for (var i = 0; i < pixels.length; i += 3) {
       pixels[i] = 204;
       pixels[i + 1] = 0;
@@ -22,7 +22,7 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].width, 10);
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgb');
-         assert.deepEqual(frames[0].pixels.slice(0, 3), new Buffer([ 204, 0, 151 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 3), Buffer.from([ 204, 0, 151 ]));
          done();
        }));
     
@@ -30,7 +30,7 @@ describe('PNGEncoder', function() {
   });
   
   it('encodes an RGBA image', function(done) {
-    var pixels = new Buffer(10 * 10 * 4);
+    var pixels = Buffer.alloc(10 * 10 * 4);
     for (var i = 0; i < pixels.length; i += 4) {
       pixels[i] = 0;
       pixels[i + 1] = 56;
@@ -46,7 +46,7 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].width, 10);
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgba');
-         assert.deepEqual(frames[0].pixels.slice(0, 4), new Buffer([ 0, 56, 128, 32 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 4), Buffer.from([ 0, 56, 128, 32 ]));
          done();
        }));
     
@@ -54,7 +54,7 @@ describe('PNGEncoder', function() {
   });
   
   it('encodes a grayscale image', function(done) {
-    var pixels = new Buffer(10 * 10);
+    var pixels = Buffer.alloc(10 * 10);
     pixels.fill(128);
     
     var enc = new PNGEncoder(10, 10, { colorSpace: 'gray' });
@@ -73,7 +73,7 @@ describe('PNGEncoder', function() {
   });
   
   it('encodes a grayscale image with alpha', function(done) {
-    var pixels = new Buffer(10 * 10 * 2);
+    var pixels = Buffer.alloc(10 * 10 * 2);
     for (var i = 0; i < pixels.length; i += 4) {
       pixels[i] = 128;
       pixels[i + 1] = 32;
@@ -87,7 +87,7 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].width, 10);
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'graya');
-         assert.deepEqual(frames[0].pixels.slice(0, 2), new Buffer([ 128, 32 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 2), Buffer.from([ 128, 32 ]));
          done();
        }));
     
@@ -95,8 +95,8 @@ describe('PNGEncoder', function() {
   });
   
   it('encodes an indexed image', function(done) {
-    var palette = new Buffer([ 204, 0, 153 ]);
-    var pixels = new Buffer(10 * 10);
+    var palette = Buffer.from([ 204, 0, 153 ]);
+    var pixels = Buffer.alloc(10 * 10);
     pixels.fill(0);
     
     var enc = new PNGEncoder(10, 10, { colorSpace: 'indexed', palette: palette });
@@ -108,7 +108,7 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgb');
          assert.equal(frames[0].pixels.length, 10 * 10 * 3);
-         assert.deepEqual(frames[0].pixels.slice(0, 3), new Buffer([ 204, 0, 153 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 3), Buffer.from([ 204, 0, 153 ]));
          done();
        }));
     
@@ -116,8 +116,8 @@ describe('PNGEncoder', function() {
   });
   
   it('encodes an indexed image with alpha', function(done) {
-    var palette = new Buffer([ 204, 0, 153, 128 ]);
-    var pixels = new Buffer(10 * 10);
+    var palette = Buffer.from([ 204, 0, 153, 128 ]);
+    var pixels = Buffer.alloc(10 * 10);
     pixels.fill(0);
     
     var enc = new PNGEncoder(10, 10, { colorSpace: 'indexed', palette: palette });
@@ -129,7 +129,7 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgba');
          assert.equal(frames[0].pixels.length, 10 * 10 * 4);
-         assert.deepEqual(frames[0].pixels.slice(0, 4), new Buffer([ 204, 0, 153, 128 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 4), Buffer.from([ 204, 0, 153, 128 ]));
          done();
        }));
     
@@ -137,8 +137,8 @@ describe('PNGEncoder', function() {
   });
   
   it('errors with invalid palette size', function(done) {
-    var palette = new Buffer([ 204, 0, 153, 1, 3 ]);
-    var pixels = new Buffer(10 * 10);
+    var palette = Buffer.from([ 204, 0, 153, 1, 3 ]);
+    var pixels = Buffer.alloc(10 * 10);
     pixels.fill(0);
     
     var enc = new PNGEncoder(10, 10, { colorSpace: 'indexed', palette: palette });
@@ -161,20 +161,20 @@ describe('PNGEncoder', function() {
       done();
     });
     
-    var pixels = new Buffer(10 * 10);
+    var pixels = Buffer.alloc(10 * 10);
     pixels.fill(0);
     enc.end(pixels);
   });
   
   it('encodes an animated image', function(done) {
-    var frame1 = new Buffer(10 * 10 * 3);
+    var frame1 = Buffer.alloc(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;
       frame1[i + 1] = 0;
       frame1[i + 2] = 151;
     }
     
-    var frame2 = new Buffer(10 * 10 * 3)
+    var frame2 = Buffer.alloc(10 * 10 * 3)
     for (var i = 0; i < frame2.length; i += 3) {
       frame2[i] = 22;
       frame2[i + 1] = 204;
@@ -190,12 +190,12 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgb');
          assert.equal(frames[0].delay, 50);
-         assert.deepEqual(frames[0].pixels.slice(0, 3), new Buffer([ 204, 0, 151 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 3), Buffer.from([ 204, 0, 151 ]));
          assert.equal(frames[1].width, 10);
          assert.equal(frames[1].height, 10);
          assert.equal(frames[1].colorSpace, 'rgb');
          assert.equal(frames[1].delay, 50);
-         assert.deepEqual(frames[1].pixels.slice(0, 3), new Buffer([ 22, 204, 13 ]));
+         assert.deepEqual(frames[1].pixels.slice(0, 3), Buffer.from([ 22, 204, 13 ]));
          
          done();
        }));
@@ -205,14 +205,14 @@ describe('PNGEncoder', function() {
   });
   
   it('supports infinite repeat count', function(done) {
-    var frame1 = new Buffer(10 * 10 * 3);
+    var frame1 = Buffer.alloc(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;
       frame1[i + 1] = 0;
       frame1[i + 2] = 151;
     }
     
-    var frame2 = new Buffer(10 * 10 * 3)
+    var frame2 = Buffer.alloc(10 * 10 * 3)
     for (var i = 0; i < frame2.length; i += 3) {
       frame2[i] = 22;
       frame2[i + 1] = 204;
@@ -229,12 +229,12 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgb');
          assert.equal(frames[0].delay, 50);
-         assert.deepEqual(frames[0].pixels.slice(0, 3), new Buffer([ 204, 0, 151 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 3), Buffer.from([ 204, 0, 151 ]));
          assert.equal(frames[1].width, 10);
          assert.equal(frames[1].height, 10);
          assert.equal(frames[1].colorSpace, 'rgb');
          assert.equal(frames[1].delay, 50);
-         assert.deepEqual(frames[1].pixels.slice(0, 3), new Buffer([ 22, 204, 13 ]));
+         assert.deepEqual(frames[1].pixels.slice(0, 3), Buffer.from([ 22, 204, 13 ]));
          assert.equal(dec.format.repeatCount, Infinity);
          done();
        }));
@@ -244,14 +244,14 @@ describe('PNGEncoder', function() {
   });
   
   it('uses frame object for delays', function(done) {
-    var frame1 = new Buffer(10 * 10 * 3);
+    var frame1 = Buffer.alloc(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;
       frame1[i + 1] = 0;
       frame1[i + 2] = 151;
     }
     
-    var frame2 = new Buffer(10 * 10 * 3)
+    var frame2 = Buffer.alloc(10 * 10 * 3)
     for (var i = 0; i < frame2.length; i += 3) {
       frame2[i] = 22;
       frame2[i + 1] = 204;
@@ -267,12 +267,12 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgb');
          assert.equal(frames[0].delay, 100);
-         assert.deepEqual(frames[0].pixels.slice(0, 3), new Buffer([ 204, 0, 151 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 3), Buffer.from([ 204, 0, 151 ]));
          assert.equal(frames[1].width, 10);
          assert.equal(frames[1].height, 10);
          assert.equal(frames[1].colorSpace, 'rgb');
          assert.equal(frames[1].delay, 50);
-         assert.deepEqual(frames[1].pixels.slice(0, 3), new Buffer([ 22, 204, 13 ]));
+         assert.deepEqual(frames[1].pixels.slice(0, 3), Buffer.from([ 22, 204, 13 ]));
          
          done();
        }));
@@ -284,9 +284,9 @@ describe('PNGEncoder', function() {
   });
   
   it('encodes an indexed animated image', function(done) {
-    var palette = new Buffer([ 204, 0, 151, 22, 204, 13 ]);
-    var frame1 = new Buffer(10 * 10);
-    var frame2 = new Buffer(10 * 10);
+    var palette = Buffer.from([ 204, 0, 151, 22, 204, 13 ]);
+    var frame1 = Buffer.alloc(10 * 10);
+    var frame2 = Buffer.alloc(10 * 10);
     frame1.fill(0);
     frame2.fill(1);
     
@@ -299,12 +299,12 @@ describe('PNGEncoder', function() {
          assert.equal(frames[0].height, 10);
          assert.equal(frames[0].colorSpace, 'rgb');
          assert.equal(frames[0].delay, 50);
-         assert.deepEqual(frames[0].pixels.slice(0, 3), new Buffer([ 204, 0, 151 ]));
+         assert.deepEqual(frames[0].pixels.slice(0, 3), Buffer.from([ 204, 0, 151 ]));
          assert.equal(frames[1].width, 10);
          assert.equal(frames[1].height, 10);
          assert.equal(frames[1].colorSpace, 'rgb');
          assert.equal(frames[1].delay, 50);
-         assert.deepEqual(frames[1].pixels.slice(0, 3), new Buffer([ 22, 204, 13 ]));
+         assert.deepEqual(frames[1].pixels.slice(0, 3), Buffer.from([ 22, 204, 13 ]));
          
          done();
        }));
@@ -314,14 +314,14 @@ describe('PNGEncoder', function() {
   });
   
   it('writes only the first frame unless animated option is set', function(done) {
-    var frame1 = new Buffer(10 * 10 * 3);
+    var frame1 = Buffer.alloc(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;
       frame1[i + 1] = 0;
       frame1[i + 2] = 151;
     }
     
-    var frame2 = new Buffer(10 * 10 * 3)
+    var frame2 = Buffer.alloc(10 * 10 * 3)
     for (var i = 0; i < frame2.length; i += 3) {
       frame2[i] = 22;
       frame2[i + 1] = 204;


### PR DESCRIPTION
This is a breaking change as it requires at least Node.js 5.10, see 'https://nodejs.org/api/buffer.html#static-method-bufferallocsize-fill-encoding'. Fixes the following Node.js deprecation warning:

> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.