### PR TITLE
refactor: migrate to esm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,43 @@
 coverage/
 node_modules/
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos
+
+### macOS ###
+# General
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos
+
+
+.idea/

--- a/decoder.mjs
+++ b/decoder.mjs
@@ -1,8 +1,8 @@
-var util = require('util');
-var Transform = require('stream').Transform;
-var BufferList = require('bl');
-var bufferEqual = require('buffer-equal');
-var zlib = require('zlib');
+import util from "util";
+import {Transform} from "stream";
+import BufferList from "bl";
+import bufferEqual from "buffer-equal";
+import zlib from "zlib";
 
 // color types
 var PNG_COLOR_TYPE_GRAY = 0;
@@ -26,7 +26,7 @@ var PNG_CRC = 3;
 
 var SIGNATURE = new Buffer([ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ]);
 
-function PNGDecoder(options) {
+export function PNGDecoder(options) {
   Transform.call(this);
 
   this._outputIndexed = (options && options.indexed) || false;
@@ -498,5 +498,3 @@ PNGDecoder.prototype._flush = function(done) {
   this._zlib.end();
   this._zlib.once('end', done);
 };
-
-module.exports = PNGDecoder;

--- a/encoder.mjs
+++ b/encoder.mjs
@@ -1,8 +1,8 @@
-var util = require('util');
-var PixelStream = require('pixel-stream');
-var zlib = require('zlib');
-var BufferList = require('bl');
-var crc32 = require('buffer-crc32');
+import util from "util";
+import PixelStream from "pixel-stream";
+import zlib from "zlib";
+import BufferList from "bl";
+import crc32 from "buffer-crc32";
 
 // color types
 var PNG_COLOR_TYPE_GRAY = 0;
@@ -29,7 +29,7 @@ var PNG_COLOR_SPACES = {
   'indexed': [ PNG_COLOR_TYPE_INDEXED, 1 ]
 };
 
-function PNGEncoder(width, height, opts) {
+export function PNGEncoder(width, height, opts) {
   PixelStream.apply(this, arguments);
   
   this._buffer = new BufferList();
@@ -325,5 +325,3 @@ function sumBuf(buf) {
   
   return sum;
 }
-
-module.exports = PNGEncoder;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-exports.Encoder = require('./encoder');
-exports.Decoder = require('./decoder');
-exports.mime = 'image/png';

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,6 @@
+import {PNGEncoder as Encoder} from './encoder.mjs';
+import {PNGDecoder as Decoder} from './decoder.mjs';
+
+const mime = 'image/png';
+
+export {Encoder, Decoder, mime}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "concat-frames": "^1.0.3",
-    "concat-stream": "^2.0.0",
     "mocha": "^11.7.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "png-stream",
   "version": "1.0.5",
   "description": "A streaming PNG encoder and decoder",
-  "main": "index.js",
+  "type": "module",
+  "main": "index.mjs",
   "directories": {
     "test": "test"
   },
@@ -13,11 +14,10 @@
     "pixel-stream": "^1.0.3"
   },
   "devDependencies": {
-    "concat-frames": "^1.0.3",
-    "mocha": "^11.7.4"
+    "concat-frames": "^1.0.3"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "test": "test"
   },
   "dependencies": {
-    "buffer-crc32": "^0.2.3",
-    "bl": "^0.9.3",
-    "buffer-equal": "^0.0.1",
+    "bl": "^6.1.3",
+    "buffer-crc32": "^1.0.0",
+    "buffer-equal": "^1.0.1",
     "pixel-stream": "^1.0.3"
   },
   "devDependencies": {
-    "concat-frames": "^1.0.1",
-    "concat-stream": "^1.4.6",
-    "mocha": "^2.0.1"
+    "concat-frames": "^1.0.3",
+    "concat-stream": "^2.0.0",
+    "mocha": "^11.7.4"
   },
   "scripts": {
     "test": "mocha"

--- a/test/decoder.mjs
+++ b/test/decoder.mjs
@@ -1,17 +1,18 @@
-var PNGDecoder = require('../decoder');
-var assert = require('assert');
-var fs = require('fs');
-var concat = require('concat-frames');
+import {PNGDecoder} from "../decoder.mjs";
+import assert from "assert";
+import fs from "fs";
+import concat from "concat-frames";
+import { describe, it } from 'node:test';
 
 describe('PNGDecoder', function() {
   it('can probe to see if a file is a png', function() {
-    var file = fs.readFileSync(__dirname + '/images/trees.png');
+    var file = fs.readFileSync(new URL('./images/trees.png', import.meta.url));
     assert(PNGDecoder.probe(file));
     assert(!PNGDecoder.probe(new Buffer(100)));
   });
 
-  it('decodes an RGB image', function(done) {
-    fs.createReadStream(__dirname + '/images/trees.png')
+  it('decodes an RGB image', function(t, done) {
+    fs.createReadStream(new URL('./images/trees.png', import.meta.url))
       .pipe(new PNGDecoder)
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 1);
@@ -24,8 +25,8 @@ describe('PNGDecoder', function() {
       }));
   });
 
-  it('decodes an RGBA image', function(done) {
-    fs.createReadStream(__dirname + '/images/djay.png')
+  it('decodes an RGBA image', function(t, done) {
+    fs.createReadStream(new URL('./images/djay.png', import.meta.url))
       .pipe(new PNGDecoder)
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 1);
@@ -38,8 +39,8 @@ describe('PNGDecoder', function() {
       }));
   });
 
-  it('decodes an indexed RGBA image', function(done) {
-    fs.createReadStream(__dirname + '/images/djay-indexed.png')
+  it('decodes an indexed RGBA image', function(t, done) {
+    fs.createReadStream(new URL('./images/djay-indexed.png', import.meta.url))
       .pipe(new PNGDecoder)
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 1);
@@ -52,8 +53,8 @@ describe('PNGDecoder', function() {
       }));
   });
 
-  it('decodes an indexed RGBA image and returns raw data given `indexed` option', function(done) {
-    fs.createReadStream(__dirname + '/images/djay-indexed.png')
+  it('decodes an indexed RGBA image and returns raw data given `indexed` option', function(t, done) {
+    fs.createReadStream(new URL('./images/djay-indexed.png', import.meta.url))
       .pipe(new PNGDecoder({ indexed: true }))
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 1);
@@ -67,8 +68,8 @@ describe('PNGDecoder', function() {
       }));
   });
 
-  it('decodes a grayscale image', function(done) {
-    fs.createReadStream(__dirname + '/images/gray.png')
+  it('decodes a grayscale image', function(t, done) {
+    fs.createReadStream(new URL('./images/gray.png', import.meta.url))
       .pipe(new PNGDecoder)
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 1);
@@ -81,8 +82,8 @@ describe('PNGDecoder', function() {
       }));
   });
 
-  it('decodes a grayscale image with alpha', function(done) {
-    fs.createReadStream(__dirname + '/images/graya.png')
+  it('decodes a grayscale image with alpha', function(t, done) {
+    fs.createReadStream(new URL('./images/graya.png', import.meta.url))
       .pipe(new PNGDecoder)
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 1);
@@ -95,8 +96,8 @@ describe('PNGDecoder', function() {
       }));
   });
 
-  it('decodes an animated image', function(done) {
-    fs.createReadStream(__dirname + '/images/chompy.png')
+  it('decodes an animated image', function(t, done) {
+    fs.createReadStream(new URL('./images/chompy.png', import.meta.url))
       .pipe(new PNGDecoder)
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 21);
@@ -112,9 +113,9 @@ describe('PNGDecoder', function() {
       }));
   });
 
-  it('errors on invalid filter algorithm', function(done) {
+  it('errors on invalid filter algorithm', function(t, done) {
     var called = false;
-    fs.createReadStream(__dirname + '/images/broken.png')
+    fs.createReadStream(new URL('./images/broken.png', import.meta.url))
       .pipe(new PNGDecoder)
       .on('error', function(err) {
         assert(err instanceof Error);
@@ -124,8 +125,8 @@ describe('PNGDecoder', function() {
       });
   });
 
-  it('handles paeth filter on the first scanline', function(done) {
-    fs.createReadStream(__dirname + '/images/image001.png')
+  it('handles paeth filter on the first scanline', function(t, done) {
+    fs.createReadStream(new URL('./images/image001.png', import.meta.url))
       .pipe(new PNGDecoder)
       .pipe(concat(function(frames) {
         assert.equal(frames.length, 1);

--- a/test/encoder.mjs
+++ b/test/encoder.mjs
@@ -1,12 +1,11 @@
-var PNGDecoder = require('../decoder');
-var PNGEncoder = require('../encoder');
-var assert = require('assert');
-var fs = require('fs');
-var concat = require('concat-frames');
-var PassThrough = require('stream').PassThrough;
+import {PNGDecoder} from "../decoder.mjs";
+import {PNGEncoder} from "../encoder.mjs";
+import assert from "assert";
+import concat from "concat-frames";
+import { describe, it } from 'node:test';
 
 describe('PNGEncoder', function() {
-  it('encodes an RGB image', function(done) {
+  it('encodes an RGB image', function(t, done) {
     var pixels = new Buffer(10 * 10 * 3);
     for (var i = 0; i < pixels.length; i += 3) {
       pixels[i] = 204;
@@ -29,7 +28,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('encodes an RGBA image', function(done) {
+  it('encodes an RGBA image', function(t, done) {
     var pixels = new Buffer(10 * 10 * 4);
     for (var i = 0; i < pixels.length; i += 4) {
       pixels[i] = 0;
@@ -53,7 +52,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('encodes a grayscale image', function(done) {
+  it('encodes a grayscale image', function(t, done) {
     var pixels = new Buffer(10 * 10);
     pixels.fill(128);
     
@@ -72,7 +71,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('encodes a grayscale image with alpha', function(done) {
+  it('encodes a grayscale image with alpha', function(t, done) {
     var pixels = new Buffer(10 * 10 * 2);
     for (var i = 0; i < pixels.length; i += 4) {
       pixels[i] = 128;
@@ -94,7 +93,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('encodes an indexed image', function(done) {
+  it('encodes an indexed image', function(t, done) {
     var palette = new Buffer([ 204, 0, 153 ]);
     var pixels = new Buffer(10 * 10);
     pixels.fill(0);
@@ -115,7 +114,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('encodes an indexed image with alpha', function(done) {
+  it('encodes an indexed image with alpha', function(t, done) {
     var palette = new Buffer([ 204, 0, 153, 128 ]);
     var pixels = new Buffer(10 * 10);
     pixels.fill(0);
@@ -136,7 +135,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('errors with invalid palette size', function(done) {
+  it('errors with invalid palette size', function(t, done) {
     var palette = new Buffer([ 204, 0, 153, 1, 3 ]);
     var pixels = new Buffer(10 * 10);
     pixels.fill(0);
@@ -152,7 +151,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('errors with missing palette', function(done) {
+  it('errors with missing palette', function(t, done) {
     var enc = new PNGEncoder(10, 10, { colorSpace: 'indexed' });
     
     enc.on('error', function(err) {
@@ -166,7 +165,7 @@ describe('PNGEncoder', function() {
     enc.end(pixels);
   });
   
-  it('encodes an animated image', function(done) {
+  it('encodes an animated image', function(t, done) {
     var frame1 = new Buffer(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;
@@ -204,7 +203,7 @@ describe('PNGEncoder', function() {
     enc.end(frame2);
   });
   
-  it('supports infinite repeat count', function(done) {
+  it('supports infinite repeat count', function(t, done) {
     var frame1 = new Buffer(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;
@@ -243,7 +242,7 @@ describe('PNGEncoder', function() {
     enc.end(frame2);
   });
   
-  it('uses frame object for delays', function(done) {
+  it('uses frame object for delays', function(t, done) {
     var frame1 = new Buffer(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;
@@ -283,7 +282,7 @@ describe('PNGEncoder', function() {
     enc.end(frame2);
   });
   
-  it('encodes an indexed animated image', function(done) {
+  it('encodes an indexed animated image', function(t, done) {
     var palette = new Buffer([ 204, 0, 151, 22, 204, 13 ]);
     var frame1 = new Buffer(10 * 10);
     var frame2 = new Buffer(10 * 10);
@@ -313,7 +312,7 @@ describe('PNGEncoder', function() {
     enc.end(frame2);
   });
   
-  it('writes only the first frame unless animated option is set', function(done) {
+  it('writes only the first frame unless animated option is set', function(t, done) {
     var frame1 = new Buffer(10 * 10 * 3);
     for (var i = 0; i < frame1.length; i += 3) {
       frame1[i] = 204;


### PR DESCRIPTION
Builds upon #9 and #10. Migrates the library from CommonJS to ES modules.
Mocha did not seem to pick up the `.mjs` tests, although the docs [state that it should work out of the box](https://mochajs.org/next/explainers/nodejs-native-esm-support/)? So I had to migrate to `node:test`
